### PR TITLE
Re-rendering optimization

### DIFF
--- a/src/features/activity-feed/comment/components/Comment/index.jsx
+++ b/src/features/activity-feed/comment/components/Comment/index.jsx
@@ -3,35 +3,37 @@ import moment from 'moment'
 import { ListItem, ListItemAvatar, Paper, Avatar, Typography, Link as MuiLink } from '@mui/material'
 import './style.scss'
 import { Link } from 'react-router-dom'
+import { useSelector } from 'react-redux'
+import { selectComment } from '../../store/commentsSelectors'
 
 Comment.propTypes = {
-    author: PropTypes.object,
-    text: PropTypes.string,
-    createdAt: PropTypes.string
+    id: PropTypes.number.isRequired
 }
 
-export function Comment({ author, text, createdAt }) {
+export function Comment({ id }) {
+    const comment = useSelector(state => selectComment(state, id))
+
     // Date and time reformatting
-    const date = moment(createdAt).format('DD/MM/YYYY')
-    const time = moment(createdAt).format('HH[h]mm')
+    const date = moment(comment.createdAt).format('DD/MM/YYYY')
+    const time = moment(comment.createdAt).format('HH[h]mm')
 
     return (
         <ListItem className="c-comment-list" alignItems="flex-start">
             <ListItemAvatar>
-                <Link to={`/${author.organization.id}/user/${author.id}`}>
-                    <Avatar alt="Remy Sharp" src={author.profilePicture} />
+                <Link to={`/${comment.author.organization.id}/user/${comment.author.id}`}>
+                    <Avatar alt="Remy Sharp" src={comment.author.profilePicture} />
                 </Link>
             </ListItemAvatar>
             <Paper className="c-comment-list__paper">
                 <MuiLink
                     component={Link}
-                    to={`/${author.organization.id}/user/${author.id}`}
+                    to={`/${comment.author.organization.id}/user/${comment.author.id}`}
                 >
                     <Typography
                         className="c-comment-list__identity"
                         variant="body1"
                     >
-                        {`${author.name} ${author.surname}`}
+                        {`${comment.author.name} ${comment.author.surname}`}
                     </Typography>
                 </MuiLink>
                 <Typography
@@ -47,10 +49,10 @@ export function Comment({ author, text, createdAt }) {
                     {date} à {time}
                 </Typography>
                 <Typography className="c-comment-list__job" variant="body2">
-                    {author.job}
+                    {comment.author.job}
                 </Typography>
                 <Typography className="c-comment-list__text" variant="body1" mt={2}>
-                    {text}
+                    {comment.text}
                 </Typography>
             </Paper>
         </ListItem>

--- a/src/features/activity-feed/comment/components/CommentsList/index.jsx
+++ b/src/features/activity-feed/comment/components/CommentsList/index.jsx
@@ -3,7 +3,7 @@ import { useCallback, useContext, useEffect, useState } from 'react'
 import { useDispatch, useSelector } from 'react-redux'
 import { Box, CircularProgress, Grid, List } from '@mui/material'
 import { Comment } from '../Comment'
-import { selectPostComments } from '../../store/commentsSelectors'
+import { selectPostCommentIds } from '../../store/commentsSelectors'
 import { fetchComments } from '../../store/commentsThunks'
 import { PostIdContext } from '../../../post/contexts/PostIdProvider'
 
@@ -14,13 +14,13 @@ CommentsList.propTypes = {
 
 export function CommentsList({ isDisplayed, onError }) {
     const postId = useContext(PostIdContext)
-    const comments = useSelector(state => selectPostComments(state, postId))
+    const commentIds = useSelector(state => selectPostCommentIds(state, postId))
     const [isLoadingComments, setIsLoadingComments] = useState(false)
 
     const dispatch = useDispatch()
 
     const loadComments = useCallback(async function () {
-        if (comments) return
+        if (commentIds) return
 
         setIsLoadingComments(true)
 
@@ -32,7 +32,7 @@ export function CommentsList({ isDisplayed, onError }) {
         } finally {
             setIsLoadingComments(false)
         }
-    }, [postId, comments, onError, dispatch])
+    }, [postId, commentIds, onError, dispatch])
 
     useEffect(() => {
         if (isDisplayed) {
@@ -48,9 +48,9 @@ export function CommentsList({ isDisplayed, onError }) {
                 </Box>
             }
             <List>
-                {comments?.map(comment => (
-                    <Grid key={comment.id}>
-                        <Comment {...comment} />
+                {commentIds?.map(commentId => (
+                    <Grid key={commentId}>
+                        <Comment id={commentId} />
                     </Grid>
                 ))}
             </List>

--- a/src/features/activity-feed/comment/store/commentsSelectors.js
+++ b/src/features/activity-feed/comment/store/commentsSelectors.js
@@ -1,4 +1,3 @@
-import { createSelector } from '@reduxjs/toolkit'
 import { selectPost } from '../../post/store/postsSelectors'
 import { commentsAdapter } from './commentsAdapter'
 
@@ -12,20 +11,8 @@ const commentsAdapterSelectors = commentsAdapter.getSelectors(
  */
 export const selectComment = commentsAdapterSelectors.selectById
 
-/**
- * @param {Object} state
- * @param {number} postId
- */
-export const selectPostCommentsCount = createSelector(
-    [selectPost],
-    post => post.commentsCount
-)
+export const selectPostCommentsCount = (state, postId) =>
+    selectPost(state, postId).commentsCount
 
-/**
- * @param {Object} state
- * @param {number} postId
- */
-export const selectPostCommentIds = createSelector(
-    [selectPost],
-    post => post.commentIds
-)
+export const selectPostCommentIds = (state, postId) =>
+    selectPost(state, postId).commentIds

--- a/src/features/activity-feed/comment/store/commentsSelectors.js
+++ b/src/features/activity-feed/comment/store/commentsSelectors.js
@@ -8,6 +8,12 @@ const commentsAdapterSelectors = commentsAdapter.getSelectors(
 
 /**
  * @param {Object} state
+ * @param {number} commentId
+ */
+export const selectComment = commentsAdapterSelectors.selectById
+
+/**
+ * @param {Object} state
  * @param {number} postId
  */
 export const selectPostCommentsCount = createSelector(
@@ -22,15 +28,4 @@ export const selectPostCommentsCount = createSelector(
 export const selectPostCommentIds = createSelector(
     [selectPost],
     post => post.commentIds
-)
-
-/**
- * @param {Object} state
- * @param {number} postId
- */
-export const selectPostComments = createSelector(
-    [state => state, selectPostCommentIds],
-    (state, postCommentIds) => postCommentIds?.map(
-        commentId => commentsAdapterSelectors.selectById(state, commentId)
-    )
 )

--- a/src/features/activity-feed/post/components/ActivityFeed/index.jsx
+++ b/src/features/activity-feed/post/components/ActivityFeed/index.jsx
@@ -2,7 +2,7 @@ import { useContext, useEffect } from 'react'
 import { useSelector, useDispatch } from 'react-redux'
 import { Box, Grid, CircularProgress } from '@mui/material'
 import { PostIdProvider } from '../../contexts/PostIdProvider'
-import { selectPosts, selectActivityFeedHasMorePosts, selectPostLoading } from '../../store/postsSelectors'
+import { selectPostIds, selectActivityFeedHasMorePosts, selectPostLoading } from '../../store/postsSelectors'
 import { fetchPosts } from '../../store/postsThunks'
 import { cleanFeedState } from '../../store/postsSlice'
 import { ProfileUserIdContext } from '../../contexts/ProfileUserIdProvider'
@@ -18,7 +18,7 @@ export function ActivityFeed() {
     const profileUserId = useContext(ProfileUserIdContext)
 
     // fetch all posts
-    const posts = useSelector(selectPosts)
+    const postIds = useSelector(selectPostIds)
     const hasMorePosts = useSelector(selectActivityFeedHasMorePosts)
     const isLoading = useSelector(selectPostLoading)
 
@@ -58,9 +58,9 @@ export function ActivityFeed() {
                 <PostForm />
             }
 
-            {posts.map(post => (
-                <Grid key={post.id}>
-                    <PostIdProvider postId={post.id}>
+            {postIds.map(postId => (
+                <Grid key={postId}>
+                    <PostIdProvider postId={postId}>
                         <Post />
                     </PostIdProvider>
                 </Grid>

--- a/src/features/activity-feed/post/components/ActivityFeedPlaceholder/index.jsx
+++ b/src/features/activity-feed/post/components/ActivityFeedPlaceholder/index.jsx
@@ -1,16 +1,16 @@
 import { useContext } from 'react'
 import { useSelector } from 'react-redux'
 import { Typography } from '@mui/material'
-import { selectPosts } from '../../store/postsSelectors'
+import { selectPostsCount } from '../../store/postsSelectors'
 import { ProfileUserIdContext } from '../../contexts/ProfileUserIdProvider'
 
 export function ActivityFeedPlaceholder() {
-    const posts = useSelector(selectPosts)
+    const postsCount = useSelector(selectPostsCount)
     const profileUserId = useContext(ProfileUserIdContext)
 
     return (
         <Typography variant="body1">
-            {posts.length > 0
+            {postsCount > 0
                 ? `Pas de posts plus anciens`
                 : profileUserId
                     ? `Cet utilisateur n'a pas encore rédigé de post`

--- a/src/features/activity-feed/post/components/Post/index.jsx
+++ b/src/features/activity-feed/post/components/Post/index.jsx
@@ -6,7 +6,7 @@ import { Card, CardActions, CardHeader, CardContent, Typography, Button, Divider
 import { HashLink } from 'react-router-hash-link'
 import { PostIdContext } from '../../contexts/PostIdProvider'
 import { selectPost } from '../../store/postsSelectors'
-import { selectPostReactionIds } from '../../../reaction/store/reactionsSelectors'
+import { selectPostReactionsCount } from '../../../reaction/store/reactionsSelectors'
 import { selectUser } from '../../../../user/store/userSelectors'
 import { CommentsList } from '../../../comment/components/CommentsList'
 import { CommentForm } from '../../../comment/components/CommentForm'
@@ -30,7 +30,7 @@ export function Post() {
     // expanding list of post comments
     const [expanded, setExpanded] = useState(false)
 
-    const reactionIds = useSelector(state => selectPostReactionIds(state, post.id))
+    const reactionsCount = useSelector(state => selectPostReactionsCount(state, post.id))
 
     const handleExpandClick = async () => {
         setExpanded(!expanded)
@@ -83,11 +83,11 @@ export function Post() {
                 </Typography>
             </CardContent>
 
-            {(reactionIds.length > 0 || post.commentsCount > 0) &&
+            {(reactionsCount > 0 || post.commentsCount > 0) &&
                 <>
                     <Divider />
                     <CardContent className="c-counter">
-                        {reactionIds.length > 0 &&
+                        {reactionsCount > 0 &&
                             <ReactionsCounter />
                         }
                         {post.commentsCount > 0 &&

--- a/src/features/activity-feed/post/components/Post/index.jsx
+++ b/src/features/activity-feed/post/components/Post/index.jsx
@@ -6,7 +6,7 @@ import { Card, CardActions, CardHeader, CardContent, Typography, Button, Divider
 import { HashLink } from 'react-router-hash-link'
 import { PostIdContext } from '../../contexts/PostIdProvider'
 import { selectPost } from '../../store/postsSelectors'
-import { selectPostReactions } from '../../../reaction/store/reactionsSelectors'
+import { selectPostReactionIds } from '../../../reaction/store/reactionsSelectors'
 import { selectUser } from '../../../../user/store/userSelectors'
 import { CommentsList } from '../../../comment/components/CommentsList'
 import { CommentForm } from '../../../comment/components/CommentForm'
@@ -30,7 +30,7 @@ export function Post() {
     // expanding list of post comments
     const [expanded, setExpanded] = useState(false)
 
-    const reactions = useSelector(state => selectPostReactions(state, post.id))
+    const reactionIds = useSelector(state => selectPostReactionIds(state, post.id))
 
     const handleExpandClick = async () => {
         setExpanded(!expanded)
@@ -83,11 +83,11 @@ export function Post() {
                 </Typography>
             </CardContent>
 
-            {(reactions.length > 0 || post.commentsCount > 0) &&
+            {(reactionIds.length > 0 || post.commentsCount > 0) &&
                 <>
                     <Divider />
                     <CardContent className="c-counter">
-                        {reactions.length > 0 &&
+                        {reactionIds.length > 0 &&
                             <ReactionsCounter />
                         }
                         {post.commentsCount > 0 &&

--- a/src/features/activity-feed/post/store/postsSelectors.js
+++ b/src/features/activity-feed/post/store/postsSelectors.js
@@ -13,7 +13,12 @@ const selectPostsState = state => state.posts
 /**
  * @param {Object} state
  */
-export const selectPosts = postsAdapterSelectors.selectAll
+export const selectPostIds = postsAdapterSelectors.selectIds
+
+/**
+ * @param {Object} state
+ */
+export const selectPostsCount = postsAdapterSelectors.selectTotal
 
 /**
  * @param {Object} state

--- a/src/features/activity-feed/post/store/postsSelectors.js
+++ b/src/features/activity-feed/post/store/postsSelectors.js
@@ -1,13 +1,9 @@
-import { createSelector } from '@reduxjs/toolkit'
 import { postsAdapter } from './postsAdapter'
 
 const postsAdapterSelectors = postsAdapter.getSelectors(
     state => state.posts
 )
 
-/**
- * @param {Object} state
- */
 const selectPostsState = state => state.posts
 
 /**
@@ -26,26 +22,10 @@ export const selectPostsCount = postsAdapterSelectors.selectTotal
  */
 export const selectPost = postsAdapterSelectors.selectById
 
-/**
- * @param {Object} state
- */
-export const selectActivityFeedCurrentPage = createSelector(
-    [selectPostsState],
-    state => state.pagination.currentPage
-)
+export const selectActivityFeedCurrentPage = state =>
+    selectPostsState(state).pagination.currentPage
 
-/**
- * @param {Object} state
- */
-export const selectActivityFeedHasMorePosts = createSelector(
-    [selectPostsState],
-    state => state.pagination.hasMorePosts
-)
+export const selectActivityFeedHasMorePosts = state =>
+    selectPostsState(state).pagination.hasMorePosts
 
-/**
- * @param {Object} state
- */
-export const selectPostLoading = createSelector(
-    [selectPostsState],
-    state => state.loading
-)
+export const selectPostLoading = state => selectPostsState(state).loading

--- a/src/features/activity-feed/reaction/components/ReactionButton/index.jsx
+++ b/src/features/activity-feed/reaction/components/ReactionButton/index.jsx
@@ -4,8 +4,7 @@ import Typography from '@mui/material/Typography'
 import Button from '@mui/material/Button'
 import { useDispatch, useSelector } from 'react-redux'
 import { PostIdContext } from '../../../post/contexts/PostIdProvider'
-import { selectPostReactions } from '../../store/reactionsSelectors'
-import { selectUserId } from '../../../../user/store/userSelectors'
+import { selectCurrentUserReactionToPost } from '../../store/reactionsSelectors'
 import { createReaction, updateReaction, removeReaction } from '../../store/reactionsThunks'
 import './style.scss'
 
@@ -13,11 +12,9 @@ export function ReactionButton() {
     const postId = useContext(PostIdContext)
     const [anchorEl, setAnchorEl] = useState(null)
     const dispatch = useDispatch()
-    const postReactions = useSelector(state => selectPostReactions(state, postId))
-
-    const userId = useSelector(selectUserId)
-
-    const loggedUserReaction = postReactions.find(reaction => userId === reaction.author.id)
+    const currentUserReaction = useSelector(
+        state => selectCurrentUserReactionToPost(state, postId)
+    )
 
     const handleClick = event => {
         setAnchorEl(event.currentTarget)
@@ -31,10 +28,10 @@ export function ReactionButton() {
     const id = open ? 'simple-popover' : undefined
 
     const handleReaction = type => {
-        if (loggedUserReaction?.type === type) {
-            dispatch(removeReaction({ postId, reactionId: loggedUserReaction.id }))
-        } else if (loggedUserReaction) {
-            dispatch(updateReaction({ type, reactionId: loggedUserReaction.id }))
+        if (currentUserReaction?.type === type) {
+            dispatch(removeReaction({ postId, reactionId: currentUserReaction.id }))
+        } else if (currentUserReaction) {
+            dispatch(updateReaction({ type, reactionId: currentUserReaction.id }))
         } else {
             dispatch(createReaction({ postId, type }))
         }
@@ -43,9 +40,9 @@ export function ReactionButton() {
 
     return (
         <div className="c-reaction-selector">
-            {loggedUserReaction
+            {currentUserReaction
                 ? <Button className="c-reaction-selector__emoji-button" aria-describedby={id} onClick={handleClick}>
-                    <img className="c-reaction-selector__image-choice" src={`/assets/reactions/emoji-${loggedUserReaction.type}.png`} alt={`Emoji ${loggedUserReaction.type}`} />
+                    <img className="c-reaction-selector__image-choice" src={`/assets/reactions/emoji-${currentUserReaction.type}.png`} alt={`Emoji ${currentUserReaction.type}`} />
                 </Button>
                 : <Button variant="outlined" className="c-btn footer" aria-describedby={id} onClick={handleClick}>
                     J'aime

--- a/src/features/activity-feed/reaction/components/ReactionButton/index.jsx
+++ b/src/features/activity-feed/reaction/components/ReactionButton/index.jsx
@@ -4,6 +4,7 @@ import Typography from '@mui/material/Typography'
 import Button from '@mui/material/Button'
 import { useDispatch, useSelector } from 'react-redux'
 import { PostIdContext } from '../../../post/contexts/PostIdProvider'
+import { REACTION_TYPES } from '../../data/reactionTypes'
 import { selectCurrentUserReactionToPost } from '../../store/reactionsSelectors'
 import { createReaction, updateReaction, removeReaction } from '../../store/reactionsThunks'
 import './style.scss'
@@ -59,24 +60,11 @@ export function ReactionButton() {
                 }}
             >
                 <Typography sx={{ p: 1 }}>
-                    <Button sx={{ m: '5px', minWidth: '35px' }} className="c-reaction-selector__emoji-button" onClick={() => handleReaction('like')}>
-                        <img className="c-reaction-selector__image" src="/assets/reactions/emoji-like.png" alt="Emoji like" />
-                    </Button>
-                    <Button sx={{ m: '5px', minWidth: '35px' }} className="c-reaction-selector__emoji-button" onClick={() => handleReaction('love')}>
-                        <img className="c-reaction-selector__image" src="/assets/reactions/emoji-love.png" alt="Emoji love" />
-                    </Button>
-                    <Button sx={{ m: '5px', minWidth: '35px' }} className="c-reaction-selector__emoji-button" onClick={() => handleReaction('haha')}>
-                        <img className="c-reaction-selector__image" src="/assets/reactions/emoji-haha.png" alt="Emoji haha" />
-                    </Button>
-                    <Button sx={{ m: '5px', minWidth: '35px' }} className="c-reaction-selector__emoji-button" onClick={() => handleReaction('wow')}>
-                        <img className="c-reaction-selector__image" src="/assets/reactions/emoji-wow.png" alt="Emoji chock" />
-                    </Button>
-                    <Button sx={{ m: '5px', minWidth: '35px' }} className="c-reaction-selector__emoji-button" onClick={() => handleReaction('sad')}>
-                        <img className="c-reaction-selector__image" src="/assets/reactions/emoji-sad.png" alt="Emoji cry" />
-                    </Button>
-                    <Button sx={{ m: '5px', minWidth: '35px' }} className="c-reaction-selector__emoji-button" onClick={() => handleReaction('angry')}>
-                        <img className="c-reaction-selector__image" src="/assets/reactions/emoji-angry.png" alt="Emoji angry" />
-                    </Button>
+                    {Object.values(REACTION_TYPES).map(reactionType =>
+                        <Button key={reactionType} sx={{ m: '5px', minWidth: '35px' }} className="c-reaction-selector__emoji-button" onClick={() => handleReaction(reactionType)}>
+                            <img className="c-reaction-selector__image" src={`/assets/reactions/emoji-${reactionType}.png`} alt={`Emoji ${reactionType}`} />
+                        </Button>
+                    )}
                 </Typography>
             </Popover>
         </div>

--- a/src/features/activity-feed/reaction/components/ReactionButton/index.jsx
+++ b/src/features/activity-feed/reaction/components/ReactionButton/index.jsx
@@ -1,7 +1,5 @@
 import { useContext, useState } from 'react'
-import Popover from '@mui/material/Popover'
-import Typography from '@mui/material/Typography'
-import Button from '@mui/material/Button'
+import { Popover, Box, Button } from '@mui/material'
 import { useDispatch, useSelector } from 'react-redux'
 import { PostIdContext } from '../../../post/contexts/PostIdProvider'
 import { REACTION_TYPES } from '../../data/reactionTypes'
@@ -59,13 +57,13 @@ export function ReactionButton() {
                     horizontal: 'left'
                 }}
             >
-                <Typography sx={{ p: 1 }}>
+                <Box sx={{ p: 1 }}>
                     {Object.values(REACTION_TYPES).map(reactionType =>
                         <Button key={reactionType} sx={{ m: '5px', minWidth: '35px' }} className="c-reaction-selector__emoji-button" onClick={() => handleReaction(reactionType)}>
                             <img className="c-reaction-selector__image" src={`/assets/reactions/emoji-${reactionType}.png`} alt={`Emoji ${reactionType}`} />
                         </Button>
                     )}
-                </Typography>
+                </Box>
             </Popover>
         </div>
 

--- a/src/features/activity-feed/reaction/components/ReactionButton/index.jsx
+++ b/src/features/activity-feed/reaction/components/ReactionButton/index.jsx
@@ -1,9 +1,9 @@
-import { useContext, useState } from 'react'
+import { useContext, useMemo, useState } from 'react'
 import { Popover, Box, Button } from '@mui/material'
 import { useDispatch, useSelector } from 'react-redux'
 import { PostIdContext } from '../../../post/contexts/PostIdProvider'
 import { REACTION_TYPES } from '../../data/reactionTypes'
-import { selectCurrentUserReactionToPost } from '../../store/reactionsSelectors'
+import { makeCurrentUserReactionToPostSelector, makePostReactionsSelector } from '../../store/reactionsSelectors'
 import { createReaction, updateReaction, removeReaction } from '../../store/reactionsThunks'
 import './style.scss'
 
@@ -11,6 +11,13 @@ export function ReactionButton() {
     const postId = useContext(PostIdContext)
     const [anchorEl, setAnchorEl] = useState(null)
     const dispatch = useDispatch()
+
+    const selectPostReactions = useMemo(makePostReactionsSelector, [])
+    const selectCurrentUserReactionToPost = useMemo(
+        () => makeCurrentUserReactionToPostSelector(selectPostReactions),
+        [selectPostReactions]
+    )
+
     const currentUserReaction = useSelector(
         state => selectCurrentUserReactionToPost(state, postId)
     )

--- a/src/features/activity-feed/reaction/components/ReactionsCounter/index.jsx
+++ b/src/features/activity-feed/reaction/components/ReactionsCounter/index.jsx
@@ -4,6 +4,7 @@ import { useSelector } from 'react-redux'
 import { Button, Popover } from '@mui/material'
 import { PostIdContext } from '../../../post/contexts/PostIdProvider'
 import { selectPostReactions } from '../../store/reactionsSelectors'
+import { REACTION_TYPES } from '../../data/reactionTypes'
 import { ReactionsList } from '../ReactionsList'
 
 export function ReactionsCounter() {
@@ -27,7 +28,7 @@ export function ReactionsCounter() {
     return (
         <>
             <Button onClick={handleClick} className="c-reaction-post">
-                {['like', 'love', 'haha', 'wow', 'sad', 'angry'].map(reactionType =>
+                {Object.values(REACTION_TYPES).map(reactionType =>
                     hasReactionType(postReactions, reactionType) && (
                         <img className="c-reaction-post__image" src={`/assets/reactions/emoji-${reactionType}.png`} alt={`Emoji ${reactionType}`} key={reactionType} />
                     )

--- a/src/features/activity-feed/reaction/components/ReactionsCounter/index.jsx
+++ b/src/features/activity-feed/reaction/components/ReactionsCounter/index.jsx
@@ -1,17 +1,24 @@
-import { useContext, useState } from 'react'
+import { useContext, useMemo, useState } from 'react'
 import './style.scss'
 import { useSelector } from 'react-redux'
 import { Button, Popover } from '@mui/material'
 import { PostIdContext } from '../../../post/contexts/PostIdProvider'
-import { selectPostReactions } from '../../store/reactionsSelectors'
-import { REACTION_TYPES } from '../../data/reactionTypes'
+import { makePostReactionsSelector, makePostReactionTypesSelector, selectPostReactionsCount } from '../../store/reactionsSelectors'
 import { ReactionsList } from '../ReactionsList'
 
 export function ReactionsCounter() {
     const postId = useContext(PostIdContext)
 
     const [anchorEl, setAnchorEl] = useState(null)
-    const postReactions = useSelector(state => selectPostReactions(state, postId))
+
+    const selectPostReactions = useMemo(makePostReactionsSelector, [])
+    const selectPostReactionTypes = useMemo(
+        () => makePostReactionTypesSelector(selectPostReactions),
+        [selectPostReactions]
+    )
+
+    const postReactionTypes = useSelector(state => selectPostReactionTypes(state, postId))
+    const postReactionsCount = useSelector(state => selectPostReactionsCount(state, postId))
 
     const handleClick = event => {
         setAnchorEl(event.currentTarget)
@@ -21,19 +28,13 @@ export function ReactionsCounter() {
         setAnchorEl(null)
     }
 
-    const hasReactionType = (reactions, type) => {
-        return reactions.some(reaction => reaction.type === type)
-    }
-
     return (
         <>
             <Button onClick={handleClick} className="c-reaction-post">
-                {Object.values(REACTION_TYPES).map(reactionType =>
-                    hasReactionType(postReactions, reactionType) && (
-                        <img className="c-reaction-post__image" src={`/assets/reactions/emoji-${reactionType}.png`} alt={`Emoji ${reactionType}`} key={reactionType} />
-                    )
+                {postReactionTypes.map(reactionType =>
+                    <img className="c-reaction-post__image" src={`/assets/reactions/emoji-${reactionType}.png`} alt={`Emoji ${reactionType}`} key={reactionType} />
                 )}
-                {postReactions.length}
+                {postReactionsCount}
             </Button>
             <Popover
                 open={Boolean(anchorEl)}

--- a/src/features/activity-feed/reaction/components/ReactionsCounter/index.jsx
+++ b/src/features/activity-feed/reaction/components/ReactionsCounter/index.jsx
@@ -5,6 +5,9 @@ import { Button, Popover } from '@mui/material'
 import { PostIdContext } from '../../../post/contexts/PostIdProvider'
 import { makePostReactionsSelector, makePostReactionTypesSelector, selectPostReactionsCount } from '../../store/reactionsSelectors'
 import { ReactionsList } from '../ReactionsList'
+import { REACTION_TYPES } from '../../data/reactionTypes'
+
+const typesOrder = Object.values(REACTION_TYPES)
 
 export function ReactionsCounter() {
     const postId = useContext(PostIdContext)
@@ -31,9 +34,13 @@ export function ReactionsCounter() {
     return (
         <>
             <Button onClick={handleClick} className="c-reaction-post">
-                {postReactionTypes.map(reactionType =>
-                    <img className="c-reaction-post__image" src={`/assets/reactions/emoji-${reactionType}.png`} alt={`Emoji ${reactionType}`} key={reactionType} />
-                )}
+                {postReactionTypes
+                    .sort((a, b) =>
+                        typesOrder.indexOf(a) - typesOrder.indexOf(b)
+                    )
+                    .map(reactionType =>
+                        <img className="c-reaction-post__image" src={`/assets/reactions/emoji-${reactionType}.png`} alt={`Emoji ${reactionType}`} key={reactionType} />
+                    )}
                 {postReactionsCount}
             </Button>
             <Popover

--- a/src/features/activity-feed/reaction/components/ReactionsList/ReactionsListItem.jsx
+++ b/src/features/activity-feed/reaction/components/ReactionsList/ReactionsListItem.jsx
@@ -3,6 +3,7 @@ import { Link } from 'react-router-dom'
 import { useSelector } from 'react-redux'
 import { Avatar, Badge, Box, styled, Link as MuiLink, Typography } from '@mui/material'
 import { selectUserOrganizationId } from '../../../../user/store/userSelectors'
+import { selectReaction } from '../../store/reactionsSelectors'
 
 const SmallAvatar = styled(Avatar)(({ theme }) => ({
     width: 20,
@@ -12,22 +13,12 @@ const SmallAvatar = styled(Avatar)(({ theme }) => ({
 }))
 
 ReactionsListItem.propTypes = {
-    reaction: PropTypes.shape({
-        id: PropTypes.number.isRequired,
-        type: PropTypes.string.isRequired,
-        author: PropTypes.shape({
-            id: PropTypes.number.isRequired,
-            name: PropTypes.string.isRequired,
-            surname: PropTypes.string.isRequired,
-            job: PropTypes.string.isRequired,
-            profilePicture: PropTypes.string
-        }).isRequired,
-        postId: PropTypes.number.isRequired
-    }).isRequired
+    id: PropTypes.number.isRequired
 }
 
-export function ReactionsListItem({ reaction }) {
+export function ReactionsListItem({ id }) {
     const organizationId = useSelector(selectUserOrganizationId)
+    const reaction = useSelector(state => selectReaction(state, id))
 
     return (
         <Box

--- a/src/features/activity-feed/reaction/components/ReactionsList/index.jsx
+++ b/src/features/activity-feed/reaction/components/ReactionsList/index.jsx
@@ -2,19 +2,19 @@ import { useContext } from 'react'
 import { useSelector } from 'react-redux'
 import { Box } from '@mui/material'
 import { PostIdContext } from '../../../post/contexts/PostIdProvider'
-import { selectPostReactions } from '../../store/reactionsSelectors'
+import { selectPostReactionIds } from '../../store/reactionsSelectors'
 import { ReactionsListItem } from './ReactionsListItem'
 
 export function ReactionsList() {
     const postId = useContext(PostIdContext)
-    const postReactions = useSelector(state => selectPostReactions(state, postId))
+    const reactionIds = useSelector(state => selectPostReactionIds(state, postId))
 
     return (
         <Box className="c-reaction-post__info">
-            {postReactions.map(reaction => (
+            {reactionIds.map(reactionId => (
                 <ReactionsListItem
-                    key={reaction.id}
-                    reaction={reaction}
+                    key={reactionId}
+                    id={reactionId}
                 />
             ))}
         </Box>

--- a/src/features/activity-feed/reaction/data/reactionTypes.js
+++ b/src/features/activity-feed/reaction/data/reactionTypes.js
@@ -1,0 +1,8 @@
+export const REACTION_TYPES = {
+    LIKE: 'like',
+    LOVE: 'love',
+    HAHA: 'haha',
+    WOW: 'wow',
+    SAD: 'sad',
+    ANGRY: 'angry'
+}

--- a/src/features/activity-feed/reaction/store/reactionsSelectors.js
+++ b/src/features/activity-feed/reaction/store/reactionsSelectors.js
@@ -1,5 +1,6 @@
 import { createSelector } from '@reduxjs/toolkit'
 import { selectPost } from '../../post/store/postsSelectors'
+import { selectUserId } from '../../../user/store/userSelectors'
 import { reactionsAdapter } from './reactionsAdapter'
 
 const reactionsAdapterSelectors = reactionsAdapter.getSelectors(
@@ -29,5 +30,16 @@ export const selectPostReactions = createSelector(
     [state => state, selectPostReactionIds],
     (state, postReactionIds) => postReactionIds.map(
         reactionId => reactionsAdapterSelectors.selectById(state, reactionId)
+    )
+)
+
+/**
+ * @param {Object} state
+ * @param {number} postId
+ */
+export const selectCurrentUserReactionToPost = createSelector(
+    [selectUserId, selectPostReactions],
+    (userId, postReactions) => postReactions.find(
+        reaction => reaction.author.id === userId
     )
 )

--- a/src/features/activity-feed/reaction/store/reactionsSelectors.js
+++ b/src/features/activity-feed/reaction/store/reactionsSelectors.js
@@ -10,6 +10,12 @@ const reactionsAdapterSelectors = reactionsAdapter.getSelectors(
  * @param {Object} state
  * @param {number} postId
  */
+export const selectReaction = reactionsAdapterSelectors.selectById
+
+/**
+ * @param {Object} state
+ * @param {number} postId
+ */
 export const selectPostReactionIds = createSelector(
     [selectPost],
     post => post.reactionIds

--- a/src/features/activity-feed/reaction/store/reactionsSelectors.js
+++ b/src/features/activity-feed/reaction/store/reactionsSelectors.js
@@ -13,14 +13,8 @@ const reactionsAdapterSelectors = reactionsAdapter.getSelectors(
  */
 export const selectReaction = reactionsAdapterSelectors.selectById
 
-/**
- * @param {Object} state
- * @param {number} postId
- */
-export const selectPostReactionIds = createSelector(
-    [selectPost],
-    post => post.reactionIds
-)
+export const selectPostReactionIds = (state, postId) =>
+    selectPost(state, postId).reactionIds
 
 /**
  * @param {Object} state

--- a/src/features/activity-feed/reaction/store/reactionsSelectors.js
+++ b/src/features/activity-feed/reaction/store/reactionsSelectors.js
@@ -1,6 +1,8 @@
 import { createSelector } from '@reduxjs/toolkit'
+import { shallowEqual } from 'react-redux'
 import { selectPost } from '../../post/store/postsSelectors'
 import { selectUserId } from '../../../user/store/userSelectors'
+import { REACTION_TYPES } from '../data/reactionTypes'
 import { reactionsAdapter } from './reactionsAdapter'
 
 const reactionsAdapterSelectors = reactionsAdapter.getSelectors(
@@ -16,24 +18,60 @@ export const selectReaction = reactionsAdapterSelectors.selectById
 export const selectPostReactionIds = (state, postId) =>
     selectPost(state, postId).reactionIds
 
+export const selectPostReactionsCount = (state, postId) =>
+    selectPostReactionIds(state, postId).length
+
 /**
- * @param {Object} state
- * @param {number} postId
+ * Creates a unique selectPostReactions selector instance with a dedicated cache
+ * per post. Meant to be used with useMemo().
+ * @see {@link https://redux.js.org/usage/deriving-data-selectors#selector-factories}
+ * @return {(state: object, postId: number) => []} Unique selectPostReactions instance
  */
-export const selectPostReactions = createSelector(
-    [state => state, selectPostReactionIds],
-    (state, postReactionIds) => postReactionIds.map(
-        reactionId => reactionsAdapterSelectors.selectById(state, reactionId)
+export const makePostReactionsSelector = () => createSelector(
+    [state => state.reactions.entities, selectPostReactionIds],
+    (reactionEntities, postReactionIds) => postReactionIds.map(reactionId =>
+        reactionEntities[reactionId]
     )
 )
 
 /**
- * @param {Object} state
- * @param {number} postId
+ * Creates a unique selectPostReactionTypes selector instance with a dedicated
+ * cache per post. It's based on a also unique selectPostReactions selector
+ * instance, so this one must be called first. Meant to be used with
+ * useMemo().
+ * @see {@link https://redux.js.org/usage/deriving-data-selectors#selector-factories}
+ * @param {function} selectPostReactions
+ * @return {(state: object, postId: number) => string[]} Unique selectPostReactionTypes instance
  */
-export const selectCurrentUserReactionToPost = createSelector(
-    [selectUserId, selectPostReactions],
-    (userId, postReactions) => postReactions.find(
-        reaction => reaction.author.id === userId
-    )
+export const makePostReactionTypesSelector = selectPostReactions => createSelector(
+    [selectPostReactions],
+    postReactions => Object.values(REACTION_TYPES).filter(reactionType =>
+        postReactions.some(reaction => reaction.type === reactionType)
+    ), {
+        // In some cases selectPostReactions returns the same array
+        // reference, so === is enough. In other cases the reference changes
+        // but the contents are the same, so shallowEqual is needed.
+        memoizeOptions: (a, b) => a === b || shallowEqual(a, b)
+    }
+)
+
+/**
+ * Creates a unique selectCurrentUserReactionToPost selector instance with a
+ * dedicated cache per post. It's based on a also unique selectPostReactions
+ * selector instance, so this one must be called first. Meant to be used with
+ * useMemo().
+ * @see {@link https://redux.js.org/usage/deriving-data-selectors#selector-factories}
+ * @param {function} selectPostReactions
+ * @return {(state: object, postId: number) => object} Unique selectCurrentUserReactionToPost instance
+ */
+export const makeCurrentUserReactionToPostSelector = selectPostReactions => createSelector(
+    [selectPostReactions, selectUserId],
+    (postReactions, userId) => postReactions.find(reaction =>
+        reaction.author.id === userId
+    ), {
+        // In some cases selectPostReactions returns the same array
+        // reference, so === is enough. In other cases the reference changes
+        // but the contents are the same, so shallowEqual is needed.
+        memoizeOptions: (a, b) => a === b || shallowEqual(a, b)
+    }
 )

--- a/src/features/activity-feed/reaction/store/reactionsSelectors.js
+++ b/src/features/activity-feed/reaction/store/reactionsSelectors.js
@@ -2,7 +2,6 @@ import { createSelector } from '@reduxjs/toolkit'
 import { shallowEqual } from 'react-redux'
 import { selectPost } from '../../post/store/postsSelectors'
 import { selectUserId } from '../../../user/store/userSelectors'
-import { REACTION_TYPES } from '../data/reactionTypes'
 import { reactionsAdapter } from './reactionsAdapter'
 
 const reactionsAdapterSelectors = reactionsAdapter.getSelectors(
@@ -45,9 +44,16 @@ export const makePostReactionsSelector = () => createSelector(
  */
 export const makePostReactionTypesSelector = selectPostReactions => createSelector(
     [selectPostReactions],
-    postReactions => Object.values(REACTION_TYPES).filter(reactionType =>
-        postReactions.some(reaction => reaction.type === reactionType)
-    ), {
+    postReactions => {
+        const types = new Set()
+        let i = 0
+
+        while (i < postReactions.length && types.size < 6) {
+            types.add(postReactions[i++].type)
+        }
+
+        return [...types]
+    }, {
         // In some cases selectPostReactions returns the same array
         // reference, so === is enough. In other cases the reference changes
         // but the contents are the same, so shallowEqual is needed.

--- a/src/features/user/store/userSelectors.js
+++ b/src/features/user/store/userSelectors.js
@@ -1,43 +1,19 @@
-import { createSelector } from '@reduxjs/toolkit'
-
 export const selectUser = state => state.user
 
-export const selectUserName = createSelector(
-    [selectUser],
-    user => user.name
-)
+export const selectUserName = state => selectUser(state).name
 
-export const selectUserIsLogged = createSelector(
-    [selectUserName],
-    name => name !== ''
-)
+export const selectUserIsLogged = state => selectUserName(state) !== ''
 
-export const selectUserOrganization = createSelector(
-    [selectUser],
-    user => user.organization
-)
+export const selectUserOrganization = state => selectUser(state).organization
 
-export const selectUserOrganizationId = createSelector(
-    [selectUserOrganization],
-    organization => organization?.id
-)
+export const selectUserOrganizationId = state =>
+    selectUserOrganization(state)?.id
 
-export const selectUserOrganizationName = createSelector(
-    [selectUserOrganization],
-    organization => organization?.name
-)
+export const selectUserOrganizationName = state =>
+    selectUserOrganization(state)?.name
 
-export const selectUserId = createSelector(
-    [selectUser],
-    user => user.id
-)
+export const selectUserId = state => selectUser(state).id
 
-export const selectUserRole = createSelector(
-    [selectUser],
-    user => user.role
-)
+export const selectUserRole = state => selectUser(state).role
 
-export const selectUserIsAdmin = createSelector(
-    [selectUserRole],
-    role => role === 'admin'
-)
+export const selectUserIsAdmin = state => selectUserRole(state) === 'admin'

--- a/src/features/user/store/userSelectors.js
+++ b/src/features/user/store/userSelectors.js
@@ -1,19 +1,13 @@
 export const selectUser = state => state.user
 
-export const selectUserName = state => selectUser(state).name
-
-export const selectUserIsLogged = state => selectUserName(state) !== ''
-
-export const selectUserOrganization = state => selectUser(state).organization
+export const selectUserIsLogged = state => selectUser(state).name !== ''
 
 export const selectUserOrganizationId = state =>
-    selectUserOrganization(state)?.id
+    selectUser(state).organization?.id
 
 export const selectUserOrganizationName = state =>
-    selectUserOrganization(state)?.name
+    selectUser(state).organization?.name
 
 export const selectUserId = state => selectUser(state).id
 
-export const selectUserRole = state => selectUser(state).role
-
-export const selectUserIsAdmin = state => selectUserRole(state) === 'admin'
+export const selectUserIsAdmin = state => selectUser(state).role === 'admin'


### PR DESCRIPTION
Many unnecessary re-rendes were triggered while using the activity feed, especially with reactions. Due to insuficiant knowledge, Redux Toolkit best practices for selectors were not always followe - for exemple, using factories when selectors are used in a list, or looping through entity IDs instead of the complete objects.

Also, since the previous branch, many selectors that didn't need memoization were using Redux Toolkit's `createSelector` function, which generates memoized selectors. They have now been reverted to simple functions.
In fact, memoization is only useful for derived data (e.g., when using `Array.map`, `Array.filter`, etc.) but is ineffective for direct access.

With all these changes, the activity feed is now more performant.