### PR TITLE
Reactions lazy loading

### DIFF
--- a/src/features/activity-feed/post/components/Post/index.jsx
+++ b/src/features/activity-feed/post/components/Post/index.jsx
@@ -1,4 +1,4 @@
-import { useContext, useState } from 'react'
+import { useContext, useMemo, useState } from 'react'
 import { Link } from 'react-router-dom'
 import { useSelector } from 'react-redux'
 import moment from 'moment'
@@ -6,7 +6,7 @@ import { Card, CardActions, CardHeader, CardContent, Typography, Button, Divider
 import { HashLink } from 'react-router-hash-link'
 import { PostIdContext } from '../../contexts/PostIdProvider'
 import { selectPost } from '../../store/postsSelectors'
-import { selectPostReactionsCount } from '../../../reaction/store/reactionsSelectors'
+import { makePostReactionsCountSelector } from '../../../reaction/store/reactionsSelectors'
 import { selectUser } from '../../../../user/store/userSelectors'
 import { CommentsList } from '../../../comment/components/CommentsList'
 import { CommentForm } from '../../../comment/components/CommentForm'
@@ -30,7 +30,14 @@ export function Post() {
     // expanding list of post comments
     const [expanded, setExpanded] = useState(false)
 
-    const reactionsCount = useSelector(state => selectPostReactionsCount(state, post.id))
+    const selectPostReactionsCount = useMemo(
+        () => makePostReactionsCountSelector(selectPost),
+        []
+    )
+
+    const reactionsCount = useSelector(state =>
+        selectPostReactionsCount(state, post.id)
+    )
 
     const handleExpandClick = async () => {
         setExpanded(!expanded)

--- a/src/features/activity-feed/post/store/postsSelectors.js
+++ b/src/features/activity-feed/post/store/postsSelectors.js
@@ -29,3 +29,6 @@ export const selectActivityFeedHasMorePosts = state =>
     selectPostsState(state).pagination.hasMorePosts
 
 export const selectPostLoading = state => selectPostsState(state).loading
+
+export const selectPostHasFetchedReactions = (state, postId) =>
+    selectPost(state, postId).hasFetchedReactions

--- a/src/features/activity-feed/post/store/postsSlice.js
+++ b/src/features/activity-feed/post/store/postsSlice.js
@@ -56,25 +56,25 @@ const postsSlice = createSlice({
             .addCase(fetchComments.fulfilled, (state, { meta: { arg: postId }, payload: comments }) => {
                 const post = postsAdapterSelectors.selectById(state, postId)
 
-                const updatedCommentIds = [
+                const commentIds = [
                     ...(post.commentIds || []),
                     ...comments.map(comment => comment.id)
                 ]
 
                 postsAdapter.updateOne(state, {
                     id: postId,
-                    changes: { commentIds: updatedCommentIds }
+                    changes: { commentIds }
                 })
             })
 
             .addCase(createComment.fulfilled, (state, { payload: comment }) => {
                 const post = postsAdapterSelectors.selectById(state, comment.postId)
-                const updatedCommentIds = [...(post.commentIds || []), comment.id]
+                const commentIds = [...(post.commentIds || []), comment.id]
 
                 postsAdapter.updateOne(state, {
                     id: comment.postId,
                     changes: {
-                        commentIds: updatedCommentIds,
+                        commentIds,
                         commentsCount: post.commentsCount + 1
                     }
                 })
@@ -82,24 +82,24 @@ const postsSlice = createSlice({
 
             .addCase(createReaction.fulfilled, (state, { payload: reaction }) => {
                 const post = postsAdapterSelectors.selectById(state, reaction.postId)
-                const updatedReactionIds = [...post.reactionIds, reaction.id]
+                const reactionIds = [...post.reactionIds, reaction.id]
 
                 postsAdapter.updateOne(state, {
                     id: reaction.postId,
-                    changes: { reactionIds: updatedReactionIds }
+                    changes: { reactionIds }
                 })
             })
 
             .addCase(removeReaction.fulfilled, (state, { meta: { arg: { postId, reactionId } } }) => {
                 const post = postsAdapterSelectors.selectById(state, postId)
 
-                const updatedReactionIds = post.reactionIds.filter(currentReactionId =>
+                const reactionIds = post.reactionIds.filter(currentReactionId =>
                     currentReactionId !== reactionId
                 )
 
                 postsAdapter.updateOne(state, {
                     id: postId,
-                    changes: { reactionIds: updatedReactionIds }
+                    changes: { reactionIds }
                 })
             })
     }

--- a/src/features/activity-feed/post/store/postsSlice.js
+++ b/src/features/activity-feed/post/store/postsSlice.js
@@ -1,6 +1,6 @@
 import { createSlice } from '@reduxjs/toolkit'
 import { fetchComments, createComment } from '../../comment/store/commentsThunks'
-import { createReaction, updateReaction, removeReaction } from '../../reaction/store/reactionsThunks'
+import { createReaction, updateReaction, removeReaction, fetchReactions } from '../../reaction/store/reactionsThunks'
 import { fetchPosts, createPost } from './postsThunks'
 import { postsAdapter } from './postsAdapter'
 
@@ -25,8 +25,13 @@ const postsSlice = createSlice({
             .addCase(fetchPosts.fulfilled, (state, { payload: { posts, meta } }) => {
                 const normalizedPosts = structuredClone(posts).map(post => {
                     post.commentIds = null
-                    post.reactionIds = post.reactions.map(reaction => reaction.id)
-                    delete post.reactions
+                    post.hasFetchedReactions = false
+                    post.reactionIds = post.currentUserReaction
+                        ? [post.currentUserReaction.id]
+                        : []
+
+                    delete post.currentUserReaction
+
                     return post
                 })
 
@@ -47,8 +52,10 @@ const postsSlice = createSlice({
             .addCase(createPost.fulfilled, (state, { payload: post }) => {
                 const normalizedPost = structuredClone(post)
                 normalizedPost.commentIds = null
+                normalizedPost.hasFetchedReactions = false
                 normalizedPost.reactionIds = []
-                delete normalizedPost.reactions
+
+                delete normalizedPost.currentUserReaction
 
                 postsAdapter.addOne(state, normalizedPost)
             })
@@ -76,6 +83,16 @@ const postsSlice = createSlice({
                     changes: {
                         commentIds,
                         commentsCount: post.commentsCount + 1
+                    }
+                })
+            })
+
+            .addCase(fetchReactions.fulfilled, (state, { meta: { arg: postId }, payload: reactions }) => {
+                postsAdapter.updateOne(state, {
+                    id: postId,
+                    changes: {
+                        reactionIds: reactions.map(reaction => reaction.id),
+                        hasFetchedReactions: true
                     }
                 })
             })

--- a/src/features/activity-feed/post/store/postsSlice.js
+++ b/src/features/activity-feed/post/store/postsSlice.js
@@ -1,6 +1,6 @@
 import { createSlice } from '@reduxjs/toolkit'
 import { fetchComments, createComment } from '../../comment/store/commentsThunks'
-import { createReaction, removeReaction } from '../../reaction/store/reactionsThunks'
+import { createReaction, updateReaction, removeReaction } from '../../reaction/store/reactionsThunks'
 import { fetchPosts, createPost } from './postsThunks'
 import { postsAdapter } from './postsAdapter'
 
@@ -82,24 +82,63 @@ const postsSlice = createSlice({
 
             .addCase(createReaction.fulfilled, (state, { payload: reaction }) => {
                 const post = postsAdapterSelectors.selectById(state, reaction.postId)
+
                 const reactionIds = [...post.reactionIds, reaction.id]
+                const reactionsCounter = {
+                    ...post.reactionsCounter,
+                    [reaction.type]: (post.reactionsCounter[reaction.type] || 0) + 1
+                }
 
                 postsAdapter.updateOne(state, {
                     id: reaction.postId,
-                    changes: { reactionIds }
+                    changes: {
+                        reactionIds,
+                        reactionsCounter
+                    }
                 })
             })
 
-            .addCase(removeReaction.fulfilled, (state, { meta: { arg: { postId, reactionId } } }) => {
-                const post = postsAdapterSelectors.selectById(state, postId)
+            .addCase(updateReaction.fulfilled, (state, { payload: { previousReaction, updatedReaction } }) => {
+                const post = postsAdapterSelectors.selectById(state, updatedReaction.postId)
 
-                const reactionIds = post.reactionIds.filter(currentReactionId =>
-                    currentReactionId !== reactionId
-                )
+                const reactionsCounter = {
+                    ...post.reactionsCounter,
+                    [previousReaction.type]: post.reactionsCounter[previousReaction.type] - 1,
+                    [updatedReaction.type]: (post.reactionsCounter[updatedReaction.type] || 0) + 1
+                }
+
+                if (reactionsCounter[previousReaction.type] === 0) {
+                    delete reactionsCounter[previousReaction.type]
+                }
 
                 postsAdapter.updateOne(state, {
-                    id: postId,
-                    changes: { reactionIds }
+                    id: updatedReaction.postId,
+                    changes: { reactionsCounter }
+                })
+            })
+
+            .addCase(removeReaction.fulfilled, (state, { payload: reaction }) => {
+                const post = postsAdapterSelectors.selectById(state, reaction.postId)
+
+                const reactionIds = post.reactionIds.filter(currentReactionId =>
+                    currentReactionId !== reaction.id
+                )
+
+                const reactionsCounter = {
+                    ...post.reactionsCounter,
+                    [reaction.type]: post.reactionsCounter[reaction.type] - 1
+                }
+
+                if (reactionsCounter[reaction.type] === 0) {
+                    delete reactionsCounter[reaction.type]
+                }
+
+                postsAdapter.updateOne(state, {
+                    id: reaction.postId,
+                    changes: {
+                        reactionIds,
+                        reactionsCounter
+                    }
                 })
             })
     }

--- a/src/features/activity-feed/reaction/components/ReactionButton/index.jsx
+++ b/src/features/activity-feed/reaction/components/ReactionButton/index.jsx
@@ -35,9 +35,9 @@ export function ReactionButton() {
 
     const handleReaction = type => {
         if (currentUserReaction?.type === type) {
-            dispatch(removeReaction({ postId, reactionId: currentUserReaction.id }))
+            dispatch(removeReaction({ postId, id: currentUserReaction.id }))
         } else if (currentUserReaction) {
-            dispatch(updateReaction({ type, reactionId: currentUserReaction.id }))
+            dispatch(updateReaction({ type, id: currentUserReaction.id }))
         } else {
             dispatch(createReaction({ postId, type }))
         }

--- a/src/features/activity-feed/reaction/components/ReactionsCounter/index.jsx
+++ b/src/features/activity-feed/reaction/components/ReactionsCounter/index.jsx
@@ -3,7 +3,8 @@ import './style.scss'
 import { useSelector } from 'react-redux'
 import { Button, Popover } from '@mui/material'
 import { PostIdContext } from '../../../post/contexts/PostIdProvider'
-import { makePostReactionsSelector, makePostReactionTypesSelector, selectPostReactionsCount } from '../../store/reactionsSelectors'
+import { selectPost } from '../../../post/store/postsSelectors'
+import { makePostReactionTypesSelector, makePostReactionsCountSelector } from '../../store/reactionsSelectors'
 import { ReactionsList } from '../ReactionsList'
 import { REACTION_TYPES } from '../../data/reactionTypes'
 
@@ -14,10 +15,14 @@ export function ReactionsCounter() {
 
     const [anchorEl, setAnchorEl] = useState(null)
 
-    const selectPostReactions = useMemo(makePostReactionsSelector, [])
     const selectPostReactionTypes = useMemo(
-        () => makePostReactionTypesSelector(selectPostReactions),
-        [selectPostReactions]
+        () => makePostReactionTypesSelector(selectPost),
+        []
+    )
+
+    const selectPostReactionsCount = useMemo(
+        () => makePostReactionsCountSelector(selectPost),
+        []
     )
 
     const postReactionTypes = useSelector(state => selectPostReactionTypes(state, postId))

--- a/src/features/activity-feed/reaction/components/ReactionsList/index.jsx
+++ b/src/features/activity-feed/reaction/components/ReactionsList/index.jsx
@@ -1,22 +1,54 @@
-import { useContext } from 'react'
-import { useSelector } from 'react-redux'
-import { Box } from '@mui/material'
+import { useContext, useEffect, useState } from 'react'
+import { useDispatch, useSelector } from 'react-redux'
+import { Box, CircularProgress } from '@mui/material'
 import { PostIdContext } from '../../../post/contexts/PostIdProvider'
+import { selectPostHasFetchedReactions } from '../../../post/store/postsSelectors'
+import { fetchReactions } from '../../store/reactionsThunks'
 import { selectPostReactionIds } from '../../store/reactionsSelectors'
 import { ReactionsListItem } from './ReactionsListItem'
 
 export function ReactionsList() {
     const postId = useContext(PostIdContext)
+
     const reactionIds = useSelector(state => selectPostReactionIds(state, postId))
+    const hasFetchedReactions = useSelector(state =>
+        selectPostHasFetchedReactions(state, postId)
+    )
+
+    const [isLoading, setIsLoading] = useState(false)
+    const dispatch = useDispatch()
+
+    useEffect(() => {
+        if (hasFetchedReactions) return
+
+        (async () => {
+            setIsLoading(true)
+
+            try {
+                await dispatch(fetchReactions(postId)).unwrap()
+            } catch (error) {
+                console.error(error) // TODO: instead of console logs, errors must be displayed directly to user
+            } finally {
+                setIsLoading(false)
+            }
+        })()
+    }, [hasFetchedReactions, postId, dispatch])
 
     return (
-        <Box className="c-reaction-post__info">
+        <Box className="c-reaction-post__info" sx={{
+            minWidth: reactionIds.length === 0 ? 180 : null
+        }}>
             {reactionIds.map(reactionId => (
                 <ReactionsListItem
                     key={reactionId}
                     id={reactionId}
                 />
             ))}
+            {isLoading && <CircularProgress sx={{
+                display: 'block',
+                mx: 'auto',
+                my: 2
+            }} />}
         </Box>
     )
 }

--- a/src/features/activity-feed/reaction/store/reactionsSelectors.js
+++ b/src/features/activity-feed/reaction/store/reactionsSelectors.js
@@ -17,9 +17,6 @@ export const selectReaction = reactionsAdapterSelectors.selectById
 export const selectPostReactionIds = (state, postId) =>
     selectPost(state, postId).reactionIds
 
-export const selectPostReactionsCount = (state, postId) =>
-    selectPostReactionIds(state, postId).length
-
 /**
  * Creates a unique selectPostReactions selector instance with a dedicated cache
  * per post. Meant to be used with useMemo().
@@ -35,30 +32,36 @@ export const makePostReactionsSelector = () => createSelector(
 
 /**
  * Creates a unique selectPostReactionTypes selector instance with a dedicated
- * cache per post. It's based on a also unique selectPostReactions selector
- * instance, so this one must be called first. Meant to be used with
- * useMemo().
+ * cache per post. It's based on a also unique selectPost selector instance, so
+ * this one must be called first. Meant to be used with useMemo().
  * @see {@link https://redux.js.org/usage/deriving-data-selectors#selector-factories}
- * @param {function} selectPostReactions
+ * @param {function} selectPost
  * @return {(state: object, postId: number) => string[]} Unique selectPostReactionTypes instance
  */
-export const makePostReactionTypesSelector = selectPostReactions => createSelector(
-    [selectPostReactions],
-    postReactions => {
-        const types = new Set()
-        let i = 0
-
-        while (i < postReactions.length && types.size < 6) {
-            types.add(postReactions[i++].type)
-        }
-
-        return [...types]
-    }, {
+export const makePostReactionTypesSelector = selectPost => createSelector(
+    [selectPost],
+    post => Object.keys(post.reactionsCounter), {
         // In some cases selectPostReactions returns the same array
         // reference, so === is enough. In other cases the reference changes
         // but the contents are the same, so shallowEqual is needed.
         memoizeOptions: (a, b) => a === b || shallowEqual(a, b)
     }
+)
+
+/**
+ * Creates a unique selectPostReactionsCount selector instance with a dedicated
+ * cache per post. It's based on a also unique selectPost selector instance, so
+ * this one must be called first. Meant to be used with useMemo().
+ * @see {@link https://redux.js.org/usage/deriving-data-selectors#selector-factories}
+ * @param {function} selectPost
+ * @return {(state: object, postId: number) => string[]} Unique selectPostReactionsCount instance
+ */
+export const makePostReactionsCountSelector = selectPost => createSelector(
+    [selectPost],
+    post => Object.values(post.reactionsCounter).reduce(
+        (total, typeCount) => total + typeCount,
+        0
+    )
 )
 
 /**

--- a/src/features/activity-feed/reaction/store/reactionsSlice.js
+++ b/src/features/activity-feed/reaction/store/reactionsSlice.js
@@ -17,7 +17,7 @@ const reactionsSlice = createSlice({
                 reactionsAdapter.addOne(state, reaction)
             })
 
-            .addCase(updateReaction.fulfilled, (state, { payload: reaction }) => {
+            .addCase(updateReaction.fulfilled, (state, { payload: { updatedReaction: reaction } }) => {
                 reactionsAdapter.setOne(state, reaction)
             })
 

--- a/src/features/activity-feed/reaction/store/reactionsSlice.js
+++ b/src/features/activity-feed/reaction/store/reactionsSlice.js
@@ -1,7 +1,7 @@
 import { createSlice } from '@reduxjs/toolkit'
 import { fetchPosts } from '../../post/store/postsThunks'
 import { cleanFeedState } from '../../post/store/postsSlice'
-import { createReaction, updateReaction, removeReaction } from './reactionsThunks'
+import { fetchReactions, createReaction, updateReaction, removeReaction } from './reactionsThunks'
 import { reactionsAdapter } from './reactionsAdapter'
 
 const reactionsSlice = createSlice({
@@ -10,7 +10,14 @@ const reactionsSlice = createSlice({
     extraReducers: builder => {
         builder
             .addCase(fetchPosts.fulfilled, (state, { payload: { posts } }) => {
-                reactionsAdapter.addMany(state, posts.flatMap(post => post.reactions))
+                reactionsAdapter.addMany(state, posts
+                    .filter(post => !!post.currentUserReaction)
+                    .map(post => post.currentUserReaction)
+                )
+            })
+
+            .addCase(fetchReactions.fulfilled, (state, { payload: reactions }) => {
+                reactionsAdapter.setMany(state, reactions)
             })
 
             .addCase(createReaction.fulfilled, (state, { payload: reaction }) => {

--- a/src/features/activity-feed/reaction/store/reactionsSlice.js
+++ b/src/features/activity-feed/reaction/store/reactionsSlice.js
@@ -21,8 +21,8 @@ const reactionsSlice = createSlice({
                 reactionsAdapter.setOne(state, reaction)
             })
 
-            .addCase(removeReaction.fulfilled, (state, { meta: { arg: { reactionId } } }) => {
-                reactionsAdapter.removeOne(state, reactionId)
+            .addCase(removeReaction.fulfilled, (state, { meta: { arg: { id } } }) => {
+                reactionsAdapter.removeOne(state, id)
             })
 
             .addCase(cleanFeedState, state => {

--- a/src/features/activity-feed/reaction/store/reactionsThunks.js
+++ b/src/features/activity-feed/reaction/store/reactionsThunks.js
@@ -1,5 +1,6 @@
 import { createAsyncThunk } from '@reduxjs/toolkit'
 import { api, fetchCsrfCookie } from '../../../../services/api'
+import { selectReaction } from './reactionsSelectors'
 
 export const createReaction = createAsyncThunk('reactions/createReaction', async ({ postId, type }, thunkApi) => {
     try {
@@ -23,7 +24,10 @@ export const updateReaction = createAsyncThunk('reactions/updateReaction', async
         await fetchCsrfCookie()
         const { data: reaction } = await api.patch(`/reactions/${reactionId}`, { type })
 
-        return reaction
+        return {
+            previousReaction: selectReaction(thunkApi.getState(), reactionId),
+            updatedReaction: reaction
+        }
     } catch (error) {
         if (error.response.status === 404) {
             return thunkApi.rejectWithValue({ status: error.response.status, message: `Cette réaction n'existe pas` })

--- a/src/features/activity-feed/reaction/store/reactionsThunks.js
+++ b/src/features/activity-feed/reaction/store/reactionsThunks.js
@@ -19,13 +19,13 @@ export const createReaction = createAsyncThunk('reactions/createReaction', async
     }
 })
 
-export const updateReaction = createAsyncThunk('reactions/updateReaction', async ({ type, reactionId }, thunkApi) => {
+export const updateReaction = createAsyncThunk('reactions/updateReaction', async ({ type, id }, thunkApi) => {
     try {
         await fetchCsrfCookie()
-        const { data: reaction } = await api.patch(`/reactions/${reactionId}`, { type })
+        const { data: reaction } = await api.patch(`/reactions/${id}`, { type })
 
         return {
-            previousReaction: selectReaction(thunkApi.getState(), reactionId),
+            previousReaction: selectReaction(thunkApi.getState(), id),
             updatedReaction: reaction
         }
     } catch (error) {
@@ -36,10 +36,10 @@ export const updateReaction = createAsyncThunk('reactions/updateReaction', async
     }
 })
 
-export const removeReaction = createAsyncThunk('reactions/removeReaction', async ({ reactionId }, thunkApi) => {
+export const removeReaction = createAsyncThunk('reactions/removeReaction', async ({ id }, thunkApi) => {
     try {
         await fetchCsrfCookie()
-        await api.delete(`/reactions/${reactionId}`)
+        await api.delete(`/reactions/${id}`)
     } catch (error) {
         if (error.response.status === 404) {
             return thunkApi.rejectWithValue({ status: error.response.status, message: `Cette réaction n'existe pas` })

--- a/src/features/activity-feed/reaction/store/reactionsThunks.js
+++ b/src/features/activity-feed/reaction/store/reactionsThunks.js
@@ -2,6 +2,19 @@ import { createAsyncThunk } from '@reduxjs/toolkit'
 import { api, fetchCsrfCookie } from '../../../../services/api'
 import { selectReaction } from './reactionsSelectors'
 
+export const fetchReactions = createAsyncThunk('reactions/fetchReactions', async (postId, thunkApi) => {
+    try {
+        const { data: reactions } = await api.get(`/posts/${postId}/reactions`)
+        return reactions
+    } catch (error) {
+        if (error.response.status === 404) {
+            return thunkApi.rejectWithValue({ status: error.response.status, message: `Ce post n'existe pas` })
+        }
+
+        return thunkApi.rejectWithValue({ status: error.response.status, message: `Une erreur s'est produite lors de la récupération des réactions` })
+    }
+})
+
 export const createReaction = createAsyncThunk('reactions/createReaction', async ({ postId, type }, thunkApi) => {
     try {
         await fetchCsrfCookie()

--- a/src/features/activity-feed/reaction/store/reactionsThunks.js
+++ b/src/features/activity-feed/reaction/store/reactionsThunks.js
@@ -40,6 +40,8 @@ export const removeReaction = createAsyncThunk('reactions/removeReaction', async
     try {
         await fetchCsrfCookie()
         await api.delete(`/reactions/${id}`)
+
+        return selectReaction(thunkApi.getState(), id)
     } catch (error) {
         if (error.response.status === 404) {
             return thunkApi.rejectWithValue({ status: error.response.status, message: `Cette réaction n'existe pas` })


### PR DESCRIPTION
Posts were fetched from the API with all their reactions, which could be slow with large datasets.
They're now lazy-loaded when clicking on the reactions counter, which drastically reduces the activity feed loading time.

Since the reaction counters and the current user reaction were previously rendered from the full reactions list, some refactoring was required to maintain these features. They now rely on two new dedicated properties from the API:
- `post.reactionsCounter`, which contains only the reaction counts grouped by type
- and `post.currentUserReaction`, which is self-explanatory

[API related PR](https://github.com/O-Network-project/o-network-api/pull/3)