### PR TITLE
Rename post resource's `reactionsCounter` property and related logic

### DIFF
--- a/src/features/activity-feed/post/store/postsSlice.js
+++ b/src/features/activity-feed/post/store/postsSlice.js
@@ -101,16 +101,16 @@ const postsSlice = createSlice({
                 const post = postsAdapterSelectors.selectById(state, reaction.postId)
 
                 const reactionIds = [...post.reactionIds, reaction.id]
-                const reactionsCounter = {
-                    ...post.reactionsCounter,
-                    [reaction.type]: (post.reactionsCounter[reaction.type] || 0) + 1
+                const reactionTypeCounts = {
+                    ...post.reactionTypeCounts,
+                    [reaction.type]: (post.reactionTypeCounts[reaction.type] || 0) + 1
                 }
 
                 postsAdapter.updateOne(state, {
                     id: reaction.postId,
                     changes: {
                         reactionIds,
-                        reactionsCounter
+                        reactionTypeCounts
                     }
                 })
             })
@@ -118,19 +118,19 @@ const postsSlice = createSlice({
             .addCase(updateReaction.fulfilled, (state, { payload: { previousReaction, updatedReaction } }) => {
                 const post = postsAdapterSelectors.selectById(state, updatedReaction.postId)
 
-                const reactionsCounter = {
-                    ...post.reactionsCounter,
-                    [previousReaction.type]: post.reactionsCounter[previousReaction.type] - 1,
-                    [updatedReaction.type]: (post.reactionsCounter[updatedReaction.type] || 0) + 1
+                const reactionTypeCounts = {
+                    ...post.reactionTypeCounts,
+                    [previousReaction.type]: post.reactionTypeCounts[previousReaction.type] - 1,
+                    [updatedReaction.type]: (post.reactionTypeCounts[updatedReaction.type] || 0) + 1
                 }
 
-                if (reactionsCounter[previousReaction.type] === 0) {
-                    delete reactionsCounter[previousReaction.type]
+                if (reactionTypeCounts[previousReaction.type] === 0) {
+                    delete reactionTypeCounts[previousReaction.type]
                 }
 
                 postsAdapter.updateOne(state, {
                     id: updatedReaction.postId,
-                    changes: { reactionsCounter }
+                    changes: { reactionTypeCounts }
                 })
             })
 
@@ -141,20 +141,20 @@ const postsSlice = createSlice({
                     currentReactionId !== reaction.id
                 )
 
-                const reactionsCounter = {
-                    ...post.reactionsCounter,
-                    [reaction.type]: post.reactionsCounter[reaction.type] - 1
+                const reactionTypeCounts = {
+                    ...post.reactionTypeCounts,
+                    [reaction.type]: post.reactionTypeCounts[reaction.type] - 1
                 }
 
-                if (reactionsCounter[reaction.type] === 0) {
-                    delete reactionsCounter[reaction.type]
+                if (reactionTypeCounts[reaction.type] === 0) {
+                    delete reactionTypeCounts[reaction.type]
                 }
 
                 postsAdapter.updateOne(state, {
                     id: reaction.postId,
                     changes: {
                         reactionIds,
-                        reactionsCounter
+                        reactionTypeCounts
                     }
                 })
             })

--- a/src/features/activity-feed/reaction/store/reactionsSelectors.js
+++ b/src/features/activity-feed/reaction/store/reactionsSelectors.js
@@ -40,7 +40,7 @@ export const makePostReactionsSelector = () => createSelector(
  */
 export const makePostReactionTypesSelector = selectPost => createSelector(
     [selectPost],
-    post => Object.keys(post.reactionsCounter), {
+    post => Object.keys(post.reactionTypeCounts), {
         // In some cases selectPostReactions returns the same array
         // reference, so === is enough. In other cases the reference changes
         // but the contents are the same, so shallowEqual is needed.
@@ -58,7 +58,7 @@ export const makePostReactionTypesSelector = selectPost => createSelector(
  */
 export const makePostReactionsCountSelector = selectPost => createSelector(
     [selectPost],
-    post => Object.values(post.reactionsCounter).reduce(
+    post => Object.values(post.reactionTypeCounts).reduce(
         (total, typeCount) => total + typeCount,
         0
     )


### PR DESCRIPTION
This property [was renamed on the API](https://github.com/O-Network-project/o-network-api/pull/4), as the previous name `reactionsCounter` was misleading — this property contains counters for each reaction type rather than a single counter. It is now renamed `reactionTypeCounts` for better grammatical and functional accuracy.