### PR TITLE
Popularity-based order for reaction counters

### DIFF
--- a/src/features/activity-feed/reaction/components/ReactionsCounter/index.jsx
+++ b/src/features/activity-feed/reaction/components/ReactionsCounter/index.jsx
@@ -25,8 +25,8 @@ export function ReactionsCounter() {
         []
     )
 
-    const postReactionTypes = useSelector(state => selectPostReactionTypes(state, postId))
-    const postReactionsCount = useSelector(state => selectPostReactionsCount(state, postId))
+    const reactionTypes = useSelector(state => selectPostReactionTypes(state, postId))
+    const reactionsCount = useSelector(state => selectPostReactionsCount(state, postId))
 
     const handleClick = event => {
         setAnchorEl(event.currentTarget)
@@ -39,14 +39,14 @@ export function ReactionsCounter() {
     return (
         <>
             <Button onClick={handleClick} className="c-reaction-post">
-                {postReactionTypes
+                {reactionTypes
                     .sort((a, b) =>
                         typesOrder.indexOf(a) - typesOrder.indexOf(b)
                     )
                     .map(reactionType =>
                         <img className="c-reaction-post__image" src={`/assets/reactions/emoji-${reactionType}.png`} alt={`Emoji ${reactionType}`} key={reactionType} />
                     )}
-                {postReactionsCount}
+                {reactionsCount}
             </Button>
             <Popover
                 open={Boolean(anchorEl)}

--- a/src/features/activity-feed/reaction/components/ReactionsCounter/index.jsx
+++ b/src/features/activity-feed/reaction/components/ReactionsCounter/index.jsx
@@ -4,28 +4,20 @@ import { useSelector } from 'react-redux'
 import { Button, Popover } from '@mui/material'
 import { PostIdContext } from '../../../post/contexts/PostIdProvider'
 import { selectPost } from '../../../post/store/postsSelectors'
-import { makePostReactionTypesSelector, makePostReactionsCountSelector } from '../../store/reactionsSelectors'
+import { selectPostReactionTypeCounts, makePostReactionsCountSelector } from '../../store/reactionsSelectors'
 import { ReactionsList } from '../ReactionsList'
-import { REACTION_TYPES } from '../../data/reactionTypes'
-
-const typesOrder = Object.values(REACTION_TYPES)
 
 export function ReactionsCounter() {
     const postId = useContext(PostIdContext)
 
     const [anchorEl, setAnchorEl] = useState(null)
 
-    const selectPostReactionTypes = useMemo(
-        () => makePostReactionTypesSelector(selectPost),
-        []
-    )
-
     const selectPostReactionsCount = useMemo(
         () => makePostReactionsCountSelector(selectPost),
         []
     )
 
-    const reactionTypes = useSelector(state => selectPostReactionTypes(state, postId))
+    const reactionTypeCounts = useSelector(state => selectPostReactionTypeCounts(state, postId))
     const reactionsCount = useSelector(state => selectPostReactionsCount(state, postId))
 
     const handleClick = event => {
@@ -39,11 +31,11 @@ export function ReactionsCounter() {
     return (
         <>
             <Button onClick={handleClick} className="c-reaction-post">
-                {reactionTypes
-                    .sort((a, b) =>
-                        typesOrder.indexOf(a) - typesOrder.indexOf(b)
+                {Object.entries(reactionTypeCounts)
+                    .sort(([, previousCount], [, nextCount]) =>
+                        nextCount - previousCount
                     )
-                    .map(reactionType =>
+                    .map(([reactionType]) =>
                         <img className="c-reaction-post__image" src={`/assets/reactions/emoji-${reactionType}.png`} alt={`Emoji ${reactionType}`} key={reactionType} />
                     )}
                 {reactionsCount}

--- a/src/features/activity-feed/reaction/store/reactionsSelectors.js
+++ b/src/features/activity-feed/reaction/store/reactionsSelectors.js
@@ -30,23 +30,8 @@ export const makePostReactionsSelector = () => createSelector(
     )
 )
 
-/**
- * Creates a unique selectPostReactionTypes selector instance with a dedicated
- * cache per post. It's based on a also unique selectPost selector instance, so
- * this one must be called first. Meant to be used with useMemo().
- * @see {@link https://redux.js.org/usage/deriving-data-selectors#selector-factories}
- * @param {function} selectPost
- * @return {(state: object, postId: number) => string[]} Unique selectPostReactionTypes instance
- */
-export const makePostReactionTypesSelector = selectPost => createSelector(
-    [selectPost],
-    post => Object.keys(post.reactionTypeCounts), {
-        // In some cases selectPostReactions returns the same array
-        // reference, so === is enough. In other cases the reference changes
-        // but the contents are the same, so shallowEqual is needed.
-        memoizeOptions: (a, b) => a === b || shallowEqual(a, b)
-    }
-)
+export const selectPostReactionTypeCounts = (state, postId) =>
+    selectPost(state, postId).reactionTypeCounts
 
 /**
  * Creates a unique selectPostReactionsCount selector instance with a dedicated


### PR DESCRIPTION
Social networks with similar reaction systems typically sort reaction types based on how often they appear on a single post. Adopting the same approach feels more familiar to users and improves app's usability.